### PR TITLE
FilteringAutomatonMatcher to support simple look-ahead / look-behind.

### DIFF
--- a/src/dk/brics/automaton/RunAutomaton.java
+++ b/src/dk/brics/automaton/RunAutomaton.java
@@ -29,6 +29,8 @@
 
 package dk.brics.automaton;
 
+import dk.brics.automaton.filter.FilteringAutomatonMatcher;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InvalidClassException;
@@ -286,5 +288,15 @@ public class RunAutomaton implements Serializable {
 	 */
 	public AutomatonMatcher newMatcher(CharSequence s, int startOffset, int endOffset)  {
 		return new AutomatonMatcher(s.subSequence(startOffset, endOffset), this);
+	}
+
+	/**
+	 * Creates a new filtering automaton matcher for the given input.
+	 *
+	 * @param s the CharSequence to search
+	 * @return A new filtering automaton matcher for the given input.
+	 */
+	public FilteringAutomatonMatcher newFilteringMatcher(CharSequence s)  {
+		return new FilteringAutomatonMatcher(s, this);
 	}
 }

--- a/src/dk/brics/automaton/filter/AutomatonCharFilter.java
+++ b/src/dk/brics/automaton/filter/AutomatonCharFilter.java
@@ -1,0 +1,71 @@
+/*
+ * dk.brics.automaton - AutomatonCharFilter
+ *
+ * Copyright (c) 2017 Bruno Roustant
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package dk.brics.automaton.filter;
+
+import dk.brics.automaton.RegExp;
+import dk.brics.automaton.RunAutomaton;
+
+/**
+ * Accepts or rejects a character based on a {@link RunAutomaton}.
+ *
+ * @author Bruno Roustant &lt;<a href="mailto:bruno.roustant@netcourrier.com">bruno.roustant@netcourrier.com</a>&gt;
+ */
+public class AutomatonCharFilter implements CharFilter {
+
+    private final RunAutomaton charFilter;
+
+    /**
+     * Constructs a {@link AutomatonCharFilter} which accepts or rejects a character based on
+     * the provided {@link RunAutomaton}.
+     * <p/>
+     * A call to {@link #accepts(char)} is equivalent to
+     * <pre>
+     *     charFilter.run(String.valueOf(c));
+     * </pre>
+     */
+    public AutomatonCharFilter(RunAutomaton charFilter) {
+        this.charFilter = charFilter;
+    }
+
+    /**
+     * Convenient constructor which builds a {@link RunAutomaton} from the provided regex.
+     *
+     * @see RegExp
+     */
+    public AutomatonCharFilter(String acceptedCharsRegex) {
+        this(new RunAutomaton(new RegExp(acceptedCharsRegex).toAutomaton()));
+    }
+
+    @Override
+    public boolean accepts(char c) {
+        int state = charFilter.step(charFilter.getInitialState(), c);
+        return state != -1 && charFilter.isAccept(state);
+    }
+}

--- a/src/dk/brics/automaton/filter/CharFilter.java
+++ b/src/dk/brics/automaton/filter/CharFilter.java
@@ -1,0 +1,43 @@
+/*
+ * dk.brics.automaton - CharFilter
+ *
+ * Copyright (c) 2017 Bruno Roustant
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package dk.brics.automaton.filter;
+
+/**
+ * Accepts or rejects a character.
+ *
+ * @author Bruno Roustant &lt;<a href="mailto:bruno.roustant@netcourrier.com">bruno.roustant@netcourrier.com</a>&gt;
+ */
+public interface CharFilter {
+
+    /**
+     * Returns whether this {@link CharFilter} accepts the character.
+     */
+    boolean accepts(char c);
+}

--- a/src/dk/brics/automaton/filter/CharLookAhead.java
+++ b/src/dk/brics/automaton/filter/CharLookAhead.java
@@ -1,0 +1,82 @@
+/*
+ * dk.brics.automaton - CharLookAhead
+ *
+ * Copyright (c) 2017 Bruno Roustant
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package dk.brics.automaton.filter;
+
+/**
+ * Accepts a match result if it fulfills a look-ahead of a single character after the last
+ * character of the match {@link FilteringAutomatonMatcher#end() end}.
+ * <p/>
+ * It is possible to create a positive look-ahead, for example to accept a match result
+ * only if it is followed by a dash or a parenthesis:
+ * <pre>
+ *   new CharLookAhead("[\\-)]"), false);
+ * </pre>
+ * <p/>
+ * It is possible to create a negative look-ahead, for example to accept a match result
+ * only if it is not followed by a word character:
+ * <pre>
+ *   new CharLookAhead("[^a-zA-Z0-9_]", true);
+ * </pre>
+ *
+ * @author Bruno Roustant &lt;<a href="mailto:bruno.roustant@netcourrier.com">bruno.roustant@netcourrier.com</a>&gt;
+ * @see FilteringAutomatonMatcher
+ */
+public class CharLookAhead implements MatchFilter {
+
+    private final CharFilter charFilter;
+    private final boolean acceptsEndOfInput;
+
+    /**
+     * Constructs a single character look-ahead.
+     *
+     * @param charFilter       The {@link CharFilter} which accepts or rejects the character
+     *                          at the match {@link FilteringAutomatonMatcher#end() end}.
+     * @param acceptsEndOfInput Whether to accept a match ending at the end of
+     *                          the input (at index {@link CharSequence#length()}).
+     */
+    public CharLookAhead(CharFilter charFilter, boolean acceptsEndOfInput) {
+        this.charFilter = charFilter;
+        this.acceptsEndOfInput = acceptsEndOfInput;
+    }
+
+    /**
+     * Convenient constructor which builds an {@link AutomatonCharFilter} from the provided regex.
+     *
+     * @see dk.brics.automaton.RegExp
+     */
+    public CharLookAhead(String acceptedCharsRegex, boolean acceptsEndOfInput) {
+        this(new AutomatonCharFilter(acceptedCharsRegex), acceptsEndOfInput);
+    }
+
+    @Override
+    public boolean accepts(int matchStart, int matchEnd, CharSequence chars) {
+        return matchEnd == chars.length() ? acceptsEndOfInput : charFilter.accepts(chars.charAt(matchEnd));
+    }
+}

--- a/src/dk/brics/automaton/filter/CharLookBehind.java
+++ b/src/dk/brics/automaton/filter/CharLookBehind.java
@@ -1,0 +1,82 @@
+/*
+ * dk.brics.automaton - CharLookBehind
+ *
+ * Copyright (c) 2017 Bruno Roustant
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package dk.brics.automaton.filter;
+
+/**
+ * Accepts a candidate match start if it fulfills a look-behind of a single character before the match
+ * {@link FilteringAutomatonMatcher#start()} start}.
+ * <p/>
+ * It is possible to create a positive look-behind, for example to accept a candidate match start
+ * only if it is preceded by a dash or a parenthesis:
+ * <pre>
+ *   new CharLookBehind("[\\-(]", false);
+ * </pre>
+ * <p/>
+ * It is possible to create a negative look-behind, for example to accept a candidate match start
+ * only if it is not preceded by a word character:
+ * <pre>
+ *   new CharLookBehind("[^a-zA-Z0-9_]", true);
+ * </pre>
+ *
+ * @author Bruno Roustant &lt;<a href="mailto:bruno.roustant@netcourrier.com">bruno.roustant@netcourrier.com</a>&gt;
+ * @see FilteringAutomatonMatcher
+ */
+public class CharLookBehind implements MatchFilter {
+
+    private final CharFilter charFilter;
+    private final boolean acceptsBeginningOfInput;
+
+    /**
+     * Constructs a single character look-behind.
+     *
+     * @param charFilter       The {@link CharFilter} which accepts or rejects the character
+     *                                preceding the character at candidate match {@link FilteringAutomatonMatcher#start() start}.
+     * @param acceptsBeginningOfInput Whether to accept a match starting at the beginning of
+     *                                the input (at index {@code 0}).
+     */
+    public CharLookBehind(CharFilter charFilter, boolean acceptsBeginningOfInput) {
+        this.charFilter = charFilter;
+        this.acceptsBeginningOfInput = acceptsBeginningOfInput;
+    }
+
+    /**
+     * Convenient constructor which builds an {@link AutomatonCharFilter} from the provided regex.
+     *
+     * @see dk.brics.automaton.RegExp
+     */
+    public CharLookBehind(String acceptedCharsRegex, boolean acceptsEndOfInput) {
+        this(new AutomatonCharFilter(acceptedCharsRegex), acceptsEndOfInput);
+    }
+
+    @Override
+    public boolean accepts(int matchStart, int matchEnd, CharSequence chars) {
+        return matchStart == 0 ? acceptsBeginningOfInput : charFilter.accepts(chars.charAt(matchStart - 1));
+    }
+}

--- a/src/dk/brics/automaton/filter/FilteringAutomatonMatcher.java
+++ b/src/dk/brics/automaton/filter/FilteringAutomatonMatcher.java
@@ -1,0 +1,113 @@
+/*
+ * dk.brics.automaton - FilteringAutomatonMatcher
+ *
+ * Copyright (c) 2017 Bruno Roustant
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package dk.brics.automaton.filter;
+
+import dk.brics.automaton.AutomatonMatcher;
+import dk.brics.automaton.RunAutomaton;
+
+/**
+ * {@link AutomatonMatcher} which filters match results with a {@link #setPreFilter(MatchFilter) pre-filter},
+  * or a {@link #setPostFilter(MatchFilter) post-filter}, or both.
+ * <p/>
+ * It is possible to filter match results with positive/negative
+ * {@link CharLookAhead look-ahead}/{@link CharLookBehind look-behind}.
+ *
+ * @author Bruno Roustant &lt;<a href="mailto:bruno.roustant@netcourrier.com">bruno.roustant@netcourrier.com</a>&gt;
+ */
+public class FilteringAutomatonMatcher extends AutomatonMatcher {
+
+    private MatchFilter preFilter;
+    private MatchFilter postFilter;
+
+    /**
+     * Creates a {@link FilteringAutomatonMatcher} based on the provided {@link RunAutomaton},
+     * with default {@link MatchFilter#ACCEPT_ALL} pre-filter and post-filter.
+     */
+    public FilteringAutomatonMatcher(CharSequence chars, RunAutomaton automaton) {
+        super(chars, automaton);
+        preFilter = MatchFilter.ACCEPT_ALL;
+        postFilter = MatchFilter.ACCEPT_ALL;
+    }
+
+    /**
+     * Sets the match pre-filter.
+     * <p/>
+     * This pre-filter will be used as a pre-validation of each candidate match start
+     * in the {@link #find()} loop. If the pre-filter rejects the match start, the {@link #find()}
+     * loop tries the next character in sequence. If the pre-filter accepts the match start,
+     * the automaton provided in the constructor is run from the candidate match start.
+     * <p/>
+     * {@code matchEnd} parameter will be {@code -1} for all calls to the pre-filter
+     * {@link MatchFilter#accepts(int, int, CharSequence)} method.
+     */
+    public FilteringAutomatonMatcher setPreFilter(MatchFilter preFilter) {
+        this.preFilter = preFilter;
+        return this;
+    }
+
+    /**
+     * Sets the match post-filter.
+     * <p/>
+     * This post-filter will be used as a post-validation of each match found by
+     * the {@link #find()} loop. If the post-filter rejects the match, the {@link #find()}
+     * loop tries to match at the next character in sequence. If the post-filter accepts the
+     * match, {@link #find()} returns {@code true}.
+     */
+    public FilteringAutomatonMatcher setPostFilter(MatchFilter postFilter) {
+        this.postFilter = postFilter;
+        return this;
+    }
+
+    /**
+     * Finds the next matching subsequence of the input which is accepted by both the
+     * {@link #setPreFilter(MatchFilter) pre-filter} and the {@link #setPostFilter(MatchFilter) post-filter}.
+     * <p/>
+     * Also updates the values for the {@link #start()}, {@link #end()}, and {@link #group()} methods.
+     *
+     * @return {@code true} if and only if there is a matching subsequence accepted by both the
+     * pre-filter and post-filter.
+     */
+    @Override
+    public boolean find() {
+        while (super.find()) {
+            int matchStart = start();
+            if (postFilter.accepts(matchStart, end(), getChars())) {
+                return true;
+            }
+            setSearchStart(matchStart + 1);
+        }
+        return false;
+    }
+
+    @Override
+    protected boolean acceptsMatchStart(int matchStart) {
+        return preFilter.accepts(matchStart, -1, getChars());
+    }
+}

--- a/src/dk/brics/automaton/filter/MatchFilter.java
+++ b/src/dk/brics/automaton/filter/MatchFilter.java
@@ -1,0 +1,62 @@
+/*
+ * dk.brics.automaton - MatchFilter
+ *
+ * Copyright (c) 2017 Bruno Roustant
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package dk.brics.automaton.filter;
+
+/**
+ * Accepts or rejects a match in a {@link CharSequence}.
+ *
+ * @author Bruno Roustant &lt;<a href="mailto:bruno.roustant@netcourrier.com">bruno.roustant@netcourrier.com</a>&gt;
+ * @see FilteringAutomatonMatcher#setPreFilter(MatchFilter)
+ * @see FilteringAutomatonMatcher#setPostFilter(MatchFilter)
+ */
+public interface MatchFilter {
+
+    /**
+     * Returns whether this {@link MatchFilter} accepts the match between
+     * {@code matchStart} inclusive and {@code matchEnd} exclusive, inside the
+     * provided {@link CharSequence}.
+     * See {@link FilteringAutomatonMatcher#setPostFilter(MatchFilter)}.
+     * <p/>
+     * {@code matchEnd} may be {@code -1} if called to pre-filter a candidate
+     * match start.
+     * See {@link FilteringAutomatonMatcher#setPreFilter(MatchFilter)}.
+     */
+    boolean accepts(int matchStart, int matchEnd, CharSequence chars);
+
+    /**
+     * {@link MatchFilter} which always accepts all matches.
+     */
+    MatchFilter ACCEPT_ALL = new MatchFilter() {
+        @Override
+        public boolean accepts(int matchStart, int matchEnd, CharSequence chars) {
+            return true;
+        }
+    };
+}

--- a/src/dk/brics/automaton/filter/MatchFilters.java
+++ b/src/dk/brics/automaton/filter/MatchFilters.java
@@ -1,0 +1,62 @@
+/*
+ * dk.brics.automaton - MatchFilters
+ *
+ * Copyright (c) 2017 Bruno Roustant
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package dk.brics.automaton.filter;
+
+/**
+ * Creates composite {@link MatchFilter}s.
+ *
+ * @author Bruno Roustant &lt;<a href="mailto:bruno.roustant@netcourrier.com">bruno.roustant@netcourrier.com</a>&gt;
+ */
+public class MatchFilters {
+
+    /**
+     * Creates a {@link MatchFilter} which is a logical AND between two delegate {@link MatchFilter}s.
+     */
+    public static MatchFilter and(MatchFilter matchFilter1, MatchFilter matchFilter2) {
+        return new And(matchFilter1, matchFilter2);
+    }
+
+    private static class And implements MatchFilter {
+
+        private final MatchFilter matchFilter1;
+        private final MatchFilter matchFilter2;
+
+        public And(MatchFilter matchFilter1, MatchFilter matchFilter2) {
+            this.matchFilter1 = matchFilter1;
+            this.matchFilter2 = matchFilter2;
+        }
+
+        @Override
+        public boolean accepts(int matchStart, int matchEnd, CharSequence chars) {
+            return matchFilter1.accepts(matchStart, matchEnd, chars)
+                    && matchFilter2.accepts(matchStart, matchEnd, chars);
+        }
+    }
+}


### PR DESCRIPTION
- New FilteringAutomatonMatcher which uses pre-filter and/or post-filter to accept or reject match results found by AutomatonMatcher.find().
- New AutomatonMatcher.setSearchStart() to set the start index of the next find().
- CharLookAhead and CharLookBehind to provide single char look-ahead / look-behind.
- MatchFilter and CharFilter interfaces to allow extensions of the filtering.
- AutomatonMatcher refactored and up to 20% faster when searching a char sequence with 0 or 1 match, same speed for more matches.