### PR TITLE
generate matching strings randomly instead of exhaustively

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>dk.brics</groupId>
-  <artifactId>automaton</artifactId>
-  <version>1.12-2</version>
+  <artifactId>brics-string-generator</artifactId>
+  <version>1.0</version>
   <packaging>jar</packaging>
 
   <name>dk.brics.automaton</name>
@@ -138,6 +138,39 @@
           </systemProperties>
         </configuration>
       </plugin>
+
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>dk.brics.automaton.BricsInputGenerator</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+
     </plugins>
   </build>
+
+	<dependencies>
+		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+		<dependency>
+		  <groupId>com.google.code.gson</groupId>
+		  <artifactId>gson</artifactId>
+		  <version>2.8.5</version>
+		</dependency>
+	</dependencies>
 </project>

--- a/src/dk/brics/automaton/BricsInputGenerator.java
+++ b/src/dk/brics/automaton/BricsInputGenerator.java
@@ -1,0 +1,61 @@
+package dk.brics.automaton;
+
+import java.util.Iterator;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import dk.brics.automaton.RegExp;
+import dk.brics.automaton.Automaton;
+import dk.brics.automaton.SpecialOperations;
+
+import java.util.Set;
+import java.util.HashSet;
+
+import com.google.gson.Gson;
+
+public class BricsInputGenerator {
+	public static void main(String[] args) {
+		if (args.length != 3) {
+			System.err.println("Generate matching strings up to length L for regex R, controlled by probability P");
+			System.err.println("usage: ... R L P");
+			System.exit(1);
+		}
+		String regexPattern = args[0];
+		int maxLength = Integer.parseInt(args[1]);
+		double prob = Double.parseDouble(args[2]);
+
+		RegExp re = new RegExp(regexPattern);
+		Automaton a = re.toAutomaton();
+
+		boolean getAllStrings = false;
+		boolean getRandStrings = true;
+
+		Set<String> acceptedAllStrings = new HashSet<String>();
+		Set<String> acceptedRandStrings = new HashSet<String>();
+		for (int i = 0; i <= maxLength; i++) {
+			if (getAllStrings) {
+				Set<String> strings = SpecialOperations.getStrings(a, i);
+				if (strings != null) {
+					acceptedAllStrings.addAll(strings);
+				}
+			}
+			
+			if (getRandStrings) {
+				Set<String> randStrings = SpecialOperations.getRandomStrings(a, i, prob);
+				if (randStrings != null) {
+					acceptedRandStrings.addAll(randStrings);
+				}
+			}
+		}
+
+		System.out.println(acceptedAllStrings.size() + " all strings");
+		for (String s : acceptedAllStrings) {
+			System.out.println("ALL STR: " + new Gson().toJson(s));
+		}
+
+		System.out.println(acceptedRandStrings.size() + " rand strings");
+		for (String s : acceptedRandStrings) {
+			System.out.println("RAND STR: " + new Gson().toJson(s));
+		}
+	}
+}


### PR DESCRIPTION
This is not a serious pull request, but the idea might be of interest and other people might want this feature.

Generating strings exhaustively may take a long time if all one desires is a random set of matching strings.

This patch:
- introduces a `getRandomStrings` method that selects transitions and transition characters randomly to reduce the set of generated strings.
- uses GSON for machine-parseable output
- modifies pom.xml so that `mvn package` produces a jar that can be executed to generate random strings up to the requested length.

For example, to generate 10 strings for the regex `/abc[0-9]+/` with 0 probability of "excessive" exploration:

```
(11:02:04) jamie@woody /tmp/dk.brics.automaton $ java -jar target/brics-string-generator-1.0.jar 'abc[0-9]+' 10 0 2>&1 | grep 'RAND STR'
RAND STR: "abc68715"
RAND STR: "abc2971316"
RAND STR: "abc53"
RAND STR: "abc7732"
RAND STR: "abc3"
RAND STR: "abc679"
RAND STR: "abc503916"
```