### PR TITLE
Re-enable JDK8 support

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,29 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # test against latest update of each LTS Java version:
+        java: [ 8, 11, 17 ]
+        # test against major operating systems
+        os: [ubuntu-20.04, windows-latest, macos-latest]
+    name: Java ${{ matrix.java }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Setup java
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'adopt'
+      - name: Build with Maven
+        run: mvn -B clean package

--- a/build.xml
+++ b/build.xml
@@ -15,7 +15,7 @@
 
 	<target name="compile">
 		<mkdir dir="antbuild" />
-		<javac srcdir="src" destdir="antbuild" source="11" target="11" optimize="${optimize}" debug="${debug}" includeantruntime="false" />
+		<javac srcdir="src" destdir="antbuild" source="1.8" target="1.8" optimize="${optimize}" debug="${debug}" includeantruntime="false" />
 	</target>
 
 	<target name="jar" depends="compile,datatypes">
@@ -75,7 +75,7 @@
 			additionalparam="-Xdoclint:none">
 			<doctitle><![CDATA[dk.brics.automaton<br>API Specification]]></doctitle>
 			<bottom><![CDATA[<i> Copyright &#169; 2001-2021 Anders M&oslash;ller. </i>]]></bottom>
-			<link href="https://docs.oracle.com/en/java/javase/11/docs/api/" />
+			<link href="https://docs.oracle.com/javase/8/docs/api/" />
 		</javadoc>
 	</target>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
@@ -104,7 +104,7 @@
           <notree>true</notree>
           <nohelp>true</nohelp>
           <links>
-            <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
+            <link>https://docs.oracle.com/javase/8/docs/api/</link>
           </links>
         </configuration>
       </plugin>


### PR DESCRIPTION
Java 8 is still quite widely used, and still is supported with bug fixes. This pull request lowers the build target to Java 8, and also include a [GitHub Actions workflow](https://github.com/dan2097/dk.brics.automaton/actions) to show that the project builds succesfully on all long-term supported versions of Java: 8, 11 and 17, as well as on various platforms. The workflow runs each time new code is comitted/whenever a pull request is recieved, so you can know if a change breaks the build.

A Java project built with a target of Java 8, is expected to work on Java 11, but the converse is not true.
@lewismc It would be great if you could confirm that this still works as you'd anticipate

This issue was also raised by @rbri here https://github.com/cs-au-dk/dk.brics.automaton/issues/29#issuecomment-896502561

I think its fine to not support Java 6/7, many other libraries have moved to Java 8 as the baseline.

