### PR TITLE
[CI] Use built-in caching functionality

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,16 +14,11 @@ jobs:
     name: Java ${{ matrix.java }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Setup java
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
+          cache: 'maven'
       - name: Build with Maven
         run: mvn -B clean package


### PR DESCRIPTION
https://github.com/actions/setup-java#caching-packages-dependencies:
> `setup-java` action has a built-in functionality for caching and restoring dependencies. It uses actions/cache under hood for caching dependencies but requires less configuration settings. 